### PR TITLE
Fix error after rename urlresolve plugin

### DIFF
--- a/script.module.urlresolver.yatse/addon.xml
+++ b/script.module.urlresolver.yatse/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.urlresolver.yatse" name="URLResolver" version="4.0.17" provider-name="Eldorado, tknorris, tvaddons">
+<addon id="script.module.urlresolver.yatse" name="URLResolver" version="4.0.18" provider-name="Eldorado, tknorris, tvaddons">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0" />
 		<import addon="script.module.python.twitch" optional="true" />

--- a/script.module.urlresolver.yatse/lib/urlresolver/lib/kodi.py
+++ b/script.module.urlresolver.yatse/lib/urlresolver/lib/kodi.py
@@ -30,7 +30,7 @@ import strings
 import CustomProgressDialog
 import urlresolver
 
-addon = xbmcaddon.Addon('script.module.urlresolver')
+addon = xbmcaddon.Addon('script.module.urlresolver.yatse')
 get_setting = addon.getSetting
 show_settings = addon.openSettings
 sleep = xbmc.sleep

--- a/script.module.urlresolver.yatse/lib/urlresolver/lib/log_utils.py
+++ b/script.module.urlresolver.yatse/lib/urlresolver/lib/log_utils.py
@@ -20,7 +20,7 @@ import xbmc
 import xbmcaddon
 from xbmc import LOGDEBUG, LOGERROR, LOGFATAL, LOGINFO, LOGNONE, LOGNOTICE, LOGSEVERE, LOGWARNING  # @UnusedImport
 
-addonsmu = xbmcaddon.Addon('script.module.urlresolver')
+addonsmu = xbmcaddon.Addon('script.module.urlresolver.yatse')
 
 def execute_jsonrpc(command):
     if not isinstance(command, basestring):


### PR DESCRIPTION
Correcting the error after renaming the plugin urlresolve. In order for it to be updated, users had to increase the release number