### PR TITLE
Fixed bug with invoking a non-existing method DialogBusy in Kodi 16 (Jarvis)

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -4,7 +4,7 @@ import urllib
 import urlresolver
 import utils
 import xbmcgui
-from utils import logger
+from utils import logger, KODI_VERSION
 
 have_youtube_dl = False
 try:
@@ -43,8 +43,12 @@ def handle_magnet(data):
 def handle_unresolved_url(data, action):
     url = urllib.unquote(data)
     if not utils.kodi_is_playing():
-        dialog = xbmcgui.DialogBusy()
-        dialog.create()
+        if KODI_VERSION <= 16:
+            dialog = xbmcgui.DialogProgress()
+            dialog.create("YATSE", "%s %s" % (action, url))
+        else:
+            dialog = xbmcgui.DialogBusy()
+            dialog.create()
         dialog.update(-1)
     else:
         dialog = None

--- a/script.yatse.kodi/lib/utils.py
+++ b/script.yatse.kodi/lib/utils.py
@@ -9,7 +9,7 @@ ADDON = xbmcaddon.Addon()
 ADDON_VERSION = ADDON.getAddonInfo('version')
 ADDON_NAME = ADDON.getAddonInfo('name')
 ADDON_ID = ADDON.getAddonInfo('id')
-
+KODI_VERSION = int(xbmc.getInfoLabel("System.BuildVersion").split()[0][:2])
 
 class XBMCHandler(logging.StreamHandler):
     xbmc_levels = {


### PR DESCRIPTION
> 17:27:56 T:2541953952  NOTICE: URLResolver: Initializing URLResolver version: 5.0.08a
17:27:57 T:2541953952  NOTICE: [script.yatse.kodi] Starting script version: 1.2.1
17:27:57 T:2541953952  NOTICE: [script.yatse.kodi] Parameters: {'action': 'share', 'queue': 'false', 'data': 'https%3A%2F%2Fyoutu.be%2Fof-UPoEnw_w', 'type': 'unresolvedurl'}
17:27:57 T:2541953952   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: 'module' object has no attribute 'DialogBusy'
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/script.yatse.kodi/default.py", line 23, in <module>
                                                commands[argument['action']](argument)
                                              File "/storage/.kodi/addons/script.yatse.kodi/lib/share.py", line 27, in run
                                                handle_unresolved_url(argument['data'], action)
                                              File "/storage/.kodi/addons/script.yatse.kodi/lib/share.py", line 46, in handle_unresolved_url
                                                dialog = xbmcgui.DialogBusy()
                                            AttributeError: 'module' object has no attribute 'DialogBusy'
                                            -->End of Python script error report<--
