### PR TITLE
Add setting to skip SSL verification on unresolved URLs

### DIFF
--- a/script.yatse.kodi/lib/utils.py
+++ b/script.yatse.kodi/lib/utils.py
@@ -93,6 +93,9 @@ def play_url(url, action, meta_data=None, use_adaptive=False):
             list_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
             list_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
     if url:
+        if get_setting('skipSslVerification') == 'true' and url.startswith('https'):
+            url = '%s|verifypeer=false' % url
+
         if (action == 'play') or (not xbmc.Player().isPlaying()):
             logger.info(u'Playing url: %s' % url)
             # Clear both playlist but only fill video as mixed playlist will work and audio will correctly play

--- a/script.yatse.kodi/resources/language/English/strings.po
+++ b/script.yatse.kodi/resources/language/English/strings.po
@@ -42,3 +42,11 @@ msgstr ""
 msgctxt "#32008"
 msgid "Prefer Kodi Youtube addon for Youtube urls"
 msgstr ""
+
+msgctxt "#32009"
+msgid "Network"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Skip SSL verification"
+msgstr ""

--- a/script.yatse.kodi/resources/settings.xml
+++ b/script.yatse.kodi/resources/settings.xml
@@ -7,4 +7,7 @@
 		<setting label="32003" type="select" id="openMagnetWith" values="Elementum|Quasar|Torrenter V2|YATP" default="Elementum"/>
 		<setting id="preferYoutubeAddon" type="bool" label="32008" default="false"/>
 	</category>
+	<category label="32009">
+		<setting id="skipSslVerification" type="bool" label="32010" default="false"/>
+	</category>
 </settings>


### PR DESCRIPTION
I've encountered a number of SSL errors when trying to send various streams from Yatse so being able to bypass the verification would be useful