### PR TITLE
Fix handling of YouTube URLs with ...?app=desktop parameter

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import lib.private.ydlfix
 import lib.utils as utils
+import re
 import xbmc
 import xbmcaddon
 from lib.utils import logger
@@ -9,9 +10,9 @@ from lib.youtube_dl import YoutubeDL
 lib.private.ydlfix.patch_youtube_dl()
 
 if utils.is_python_3():
-    from urllib.parse import unquote
+    from urllib.parse import unquote, urlparse, urlunparse
 else:
-    from urllib import unquote
+    from urllib import unquote, urlparse, urlunparse
 
 have_adaptive_plugin = '"enabled":true' in xbmc.executeJSONRPC('{"jsonrpc":"2.0","method":"Addons.GetAddonDetails","id":1,"params":{"addonid":"inputstream.adaptive", "properties": ["enabled"]}}')
 
@@ -97,6 +98,10 @@ def handle_unresolved_url(data, action):
         if youtube_addon:
             if utils.get_setting('preferYoutubeAddon') == 'true' or youtube_addon.getSetting("kodion.video.quality.mpd") == "true":
                 logger.info(u'Youtube addon have DASH enabled or is configured as preferred use it')
+                clean_url = list(urlparse(url))
+                clean_url[4] = '&'.join(
+                    [x for x in clean_url[4].split('&') if not re.match(r'app=', x)])
+                url = urlunparse(clean_url)
                 utils.play_url('plugin://plugin.video.youtube/uri2addon/?uri=%s' % url, action)
                 return
     logger.info(u'Trying to resolve with YoutubeDL')


### PR DESCRIPTION
Some YouTube URLs one would encounter in mobile apps, most notably ones that are shared to Facebook, consist of links that look like this:

  https://www.youtube.com/watch?app=desktop&v=zpkh7_Eyctw&feature=share

i.e., for browser clients, they explicit request desktop view. (Don't ask me WHY anyone would want that.)

Trying to play such an URL on Kodi (with MPEG-DASH enabled, in case that makes a difference) causes a playback error, since apparently the video ID is expected right at the beginning of the URL parameters, in the URI string passed to uri2addon, not any of the later parameters that are passed separately.

I've created a quick and dirty patch that removes an extraneous `app=whatever` parameter from YouTube URLs. With this patch, I can share such links directly from the Facebook app to Kodi, without having to share to the YouTube app first and then on from there (which used to be my workaround until today).