### PR TITLE
Use correct (quoted) variant of URL when used as argument for uri2addon

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -97,7 +97,7 @@ def handle_unresolved_url(data, action):
         if youtube_addon:
             if utils.get_setting('preferYoutubeAddon') == 'true' or youtube_addon.getSetting("kodion.video.quality.mpd") == "true":
                 logger.info(u'Youtube addon have DASH enabled or is configured as preferred use it')
-                utils.play_url('plugin://plugin.video.youtube/uri2addon/?uri=%s' % url, action)
+                utils.play_url('plugin://plugin.video.youtube/uri2addon/?uri=%s' % data, action)
                 return
     logger.info(u'Trying to resolve with YoutubeDL')
     result = resolve_with_youtube_dl(url, {'format': 'best', 'no_color': 'true', 'ignoreerrors': 'true'}, action)


### PR DESCRIPTION
Proper fix for #26 - when a whole shared URI is used with uri2addon, it needs to be correctly quoted. Since the quoted value is already available in `data`, simply use that.