### PR TITLE
Added feature for using cookies for YoutubeDL from browser, updated russian translation

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -41,6 +41,12 @@ def handle_magnet(data):
 
 
 def resolve_with_youtube_dl(url, parameters, action):
+    if (utils.get_setting('useCookiesFromBrowser')):
+        browserName = utils.get_setting('cookiesBrowserName')
+        
+        if browserName:
+            parameters['cookiesfrombrowser'] = [browserName]
+
     youtube_dl_resolver = YoutubeDL(parameters)
     youtube_dl_resolver.add_default_info_extractors()
     try:

--- a/script.yatse.kodi/resources/language/English/strings.po
+++ b/script.yatse.kodi/resources/language/English/strings.po
@@ -50,3 +50,11 @@ msgstr ""
 msgctxt "#32010"
 msgid "Skip SSL verification"
 msgstr ""
+
+msgctxt "#32011"
+msgid "Use cookies from browser for YoutubeDL"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Browser with cookies for YoutubeDL"
+msgstr ""

--- a/script.yatse.kodi/resources/language/Russian/strings.po
+++ b/script.yatse.kodi/resources/language/Russian/strings.po
@@ -34,3 +34,27 @@ msgstr "Проверьте, есть ли обновление для этого
 msgctxt "#32006"
 msgid "Unable to resolve the shared url."
 msgstr "Не удалось определить общий URL"
+
+msgctxt "#32007"
+msgid "Resolving shared media."
+msgstr "Обработка переданной ссылки."
+
+msgctxt "#32008"
+msgid "Prefer Kodi Youtube addon for Youtube urls"
+msgstr "Предпочитать дополнение YouTube для Kodi при открытии ссылок на YouTube"
+
+msgctxt "#32009"
+msgid "Network"
+msgstr "Сеть"
+
+msgctxt "#32010"
+msgid "Skip SSL verification"
+msgstr "Отключить проверку SSL сертификатов"
+
+msgctxt "#32011"
+msgid "Use cookies from browser for YoutubeDL"
+msgstr "Использовать для YoutubeDL cookies из браузера"
+
+msgctxt "#32012"
+msgid "Browser with cookies for YoutubeDL"
+msgstr "Браузер с cookies для YoutubeDL"

--- a/script.yatse.kodi/resources/settings.xml
+++ b/script.yatse.kodi/resources/settings.xml
@@ -6,6 +6,8 @@
 	<category label="32001">
 		<setting label="32003" type="select" id="openMagnetWith" values="Elementum|Quasar|Torrenter V2|YATP" default="Elementum"/>
 		<setting id="preferYoutubeAddon" type="bool" label="32008" default="false"/>
+		<setting id="useCookiesFromBrowser" type="bool" label="32011" default="false"/>
+		<setting id="cookiesBrowserName" type="select" label="32012" values="firefox|safari|brave|chrome|chromium|edge|opera|vivaldi" visible="eq(-1,true)" />
 	</category>
 	<category label="32009">
 		<setting id="skipSslVerification" type="bool" label="32010" default="false"/>


### PR DESCRIPTION
I've added feature for passing argument "cookiesfrombrowser" to yt-dlp with browser name. Feature can be enabled in settings. It can be useful, if you're sharing link to site with authentication, or with captcha, so you can login to site in browser and share link with Kodi. Also I've updated russian translation.