### PR TITLE
Add http headers to requested URL

### DIFF
--- a/script.yatse.kodi/lib/utils.py
+++ b/script.yatse.kodi/lib/utils.py
@@ -22,6 +22,10 @@ if is_python_3():
     # noinspection PyShadowingBuiltins
     unicode = str
 
+if is_python_3():
+    from urllib.parse import quote
+else:
+    from urllib import quote
 
 class XBMCHandler(logging.StreamHandler):
     xbmc_levels = {
@@ -86,6 +90,13 @@ def play_url(url, action, meta_data=None, use_adaptive=False):
         if use_adaptive:
             list_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
             list_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+
+        http_headers = meta_data.get('http_headers', {})
+
+        # Append http headers to simulate the same browser used by yt-dlp in the extract_info
+        for i, (k, v) in enumerate(http_headers.items()):
+            url = url + ('|' if i == 0 else '&')
+            url = url + f"{quote(k)}={quote(v)}"
     else:
         list_item = None
         if use_adaptive:


### PR DESCRIPTION
In the last couple of months, some video streaming services (eg. redgifs, pornhub) have stopped working with your addon.

I think is related to the different http header used between the first request through yt-dlp (ie. `extract_info()`) and the kodi request made by `xbmc.Player().play()`. [Here](https://github.com/yt-dlp/yt-dlp/issues/4805#issuecomment-1241424276) for more details. 

Should be enough pass only the *user-agent*, but I have preferred add all http headers payload.

Anyway, there is still a problem: after the first playback, the second one doesn't work...but I was not able to solve/fix this issue :sob:

You can find a trimmed log here: https://pastebin.com/3iPQbeX9

As you can see the second shared video at "2023-03-14 09:50:20.940 T:924978" return:

> 2023-03-14 09:50:22.368 T:924978   error <general>: ERROR: 'NoneType' object is not callable

I have tried:
* Using a simple python script (unrelated with kodi) that uses yt-dlp and downloads two videos in sequence => WORKS
* Putting the same python script in your `default.py` removing all the rest of code => NOT WORKS
* Using locally installed yt-dlp inside your addon => NOT WORKS

The error throws inside the yt-dlp library, but I don't know where (without an error stack)...
I guess the issue is related to python version (does kodi use a different version respect the one installed on my system?).

Sorry for the long text...and thanks a lot for your projects!

