### PR TITLE
Added URL trimming for YoutubeDL, fixed disabling of usage cookies from browser, updated Russian translation

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -41,9 +41,9 @@ def handle_magnet(data):
 
 
 def resolve_with_youtube_dl(url, parameters, action):
-    if (utils.get_setting('useCookiesFromBrowser')):
+    if (utils.get_setting('useCookiesFromBrowser') == 'true'):
         browserName = utils.get_setting('cookiesBrowserName')
-        
+
         if browserName:
             parameters['cookiesfrombrowser'] = [browserName]
 

--- a/script.yatse.kodi/lib/utils.py
+++ b/script.yatse.kodi/lib/utils.py
@@ -85,6 +85,7 @@ def kodi_is_playing():
 
 
 def play_url(url, action, meta_data=None, use_adaptive=False):
+    url = url.strip()
     kodi_url_params = {}
     if meta_data is not None:
         list_item = get_kodi_list_item(meta_data)
@@ -190,7 +191,7 @@ def get_kodi_list_item(meta_data):
     if 'duration' in meta_data:
         item_info['duration'] = meta_data['duration']
     if 'url' in meta_data:
-        list_item.setPath(meta_data['url'])
+        list_item.setPath(meta_data['url'].strip())
     if 'categories' in meta_data:
         item_info['genre'] = meta_data['categories']
     if 'average_rating' in meta_data:

--- a/script.yatse.kodi/resources/language/Russian/strings.po
+++ b/script.yatse.kodi/resources/language/Russian/strings.po
@@ -58,3 +58,15 @@ msgstr "Использовать для YoutubeDL cookies из браузера"
 msgctxt "#32012"
 msgid "Browser with cookies for YoutubeDL"
 msgstr "Браузер с cookies для YoutubeDL"
+
+msgctxt "#32013"
+msgid "Use YoutubeDL http headers"
+msgstr "Использовать HTTP заголовки YoutubeDL"
+
+msgctxt "#32100"
+msgid "Use custom YoutubeDL format filter"
+msgstr "Использовать кастомный формат фильтра для YoutubeDL"
+
+msgctxt "#32101"
+msgid "Preferred YoutubeDL format"
+msgstr "Предпочитаемый формат YoutubeDL"


### PR DESCRIPTION
Hello. I've added trimming for URLs from YoutubeDL (it can be useful when you share a link to Kodi through the Yatse app because some services return URLs with whitespaces, which breaks further playing of such URLs in Kodi). Also I've fixed disabling of passing cookies to YoutubeDL from browser (it worked incorrectly due to a change in settings loading mechanism). And finally, I've updated Russian translation of the add-on.