### PR TITLE
New: Add Kodi ARTE.tv Addon URL handler

### DIFF
--- a/script.yatse.kodi/lib/share.py
+++ b/script.yatse.kodi/lib/share.py
@@ -93,6 +93,18 @@ def resolve_with_youtube_dl(url, parameters, action):
 
 def handle_unresolved_url(data, action):
     url = unquote(data)
+
+    if utils.get_setting('preferArteAddon') == 'true' and "arte.tv" in url:
+        ARTE_PLUGIN_ID = 'plugin.video.tyl0re.arte'
+        if utils.addon_exists(ARTE_PLUGIN_ID):
+            logger.info(u'Passing URL (%s) to ARTE Plugin (%s) as per current user settings' % (url,ARTE_PLUGIN_ID))
+            xbmc.Player().play('plugin://%s/?mode=playVideo&url=%s' % (ARTE_PLUGIN_ID,url))
+            return True
+        else:
+            errmsg='Arte addon is not installed. Passing URL to regular handling. Please install Arte addon manually or deactivate using Arte arte in settings'
+            logger.error(errmsg)
+            utils.show_error_notification(errmsg)
+    
     logger.info(u'Trying to resolve URL (%s): %s' % (action, url))
     if xbmc.Player().isPlaying():
         utils.show_info_notification(utils.translation(32007), 1000)

--- a/script.yatse.kodi/lib/utils.py
+++ b/script.yatse.kodi/lib/utils.py
@@ -266,3 +266,6 @@ def get_list_item_path(list_item):
         return list_item.getPath()
     else:
         return list_item.getfilename()
+    
+def addon_exists(addon_name):
+    return xbmc.getCondVisibility('System.HasAddon(%s)' % addon_name) == 1

--- a/script.yatse.kodi/resources/language/English/strings.po
+++ b/script.yatse.kodi/resources/language/English/strings.po
@@ -63,10 +63,18 @@ msgctxt "#32013"
 msgid "Use YoutubeDL http headers"
 msgstr ""
 
+msgctxt "#32014"
+msgid "URL Handlers"
+msgstr ""
+
 msgctxt "#32100"
 msgid "Use custom YoutubeDL format filter"
 msgstr ""
 
 msgctxt "#32101"
 msgid "Preferred YoutubeDL format"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Prefer Kodi Arte addon for arte.tv urls"
 msgstr ""

--- a/script.yatse.kodi/resources/settings.xml
+++ b/script.yatse.kodi/resources/settings.xml
@@ -4,14 +4,17 @@
 	   <setting id="logEnabled" type="bool" label="32002" default="false"/>
 	</category>
 	<category label="32001">
-		<setting label="32003" type="select" id="openMagnetWith" values="Elementum|Quasar|Torrenter V2|YATP" default="Elementum"/>
-		<setting id="preferYoutubeAddon" type="bool" label="32008" default="false"/>
 		<setting id="useCookiesFromBrowser" type="bool" label="32011" default="false"/>
 		<setting id="cookiesBrowserName" type="select" label="32012" values="firefox|safari|brave|chrome|chromium|edge|opera|vivaldi" visible="eq(-1,true)" />
 		<setting id="useYoutubeDLHttpHeader" type="bool" label="32013" default="true"/>
 		<setting id="useYoutubeDLCustomFilter" type="bool" label="32100" default="false"/>
 		<setting id="YoutubeDLCustomMediaFilter" type="text" label="32101" default="" visible="eq(-1,true)"/>
 	</category>
+	<category label="32014">
+		<setting label="32003" type="select" id="openMagnetWith" values="Elementum|Quasar|Torrenter V2|YATP" default="Elementum"/>
+		<setting id="preferYoutubeAddon" type="bool" label="32008" default="false"/>
+		<setting id="preferArteAddon" type="bool" label="32102" default="false"/>
+	</category>	
 	<category label="32009">
 		<setting id="skipSslVerification" type="bool" label="32010" default="false"/>
 	</category>


### PR DESCRIPTION
HLS media stream urls retrieved per default by yatse/youtubeDL for Arte.tv URLs (...arte.tv) frequently fail to open with inputstream.adaptive on Kodi 19.4 on Raspberry 3  with a demuxer error (probably due to an outdated  ffmpeg component/library).
Patch adds a new option to pass on Arte URLs directly to Kodi Arte.tv addon (https://www.kodi-tipps.de/arte-kodi-addon-installieren/; if installed), which allows further, working fallback options to successfully play the stream.
