### PR TITLE
Fix datetime.datetime.strptime() 'NoneType' error

### DIFF
--- a/script.yatse.kodi/lib/private/ydlfix.py
+++ b/script.yatse.kodi/lib/private/ydlfix.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
+import datetime
+import time
 
 from ..youtube_dl import utils
 
@@ -76,9 +78,19 @@ class ReplacementStdErr(sys.stderr.__class__):
         return False
 
 
+class proxydt(datetime.datetime):
+
+    @classmethod
+    def strptime(cls, date_string, format):
+        return datetime.datetime(*(time.strptime(date_string, format)[:6]))
+
+
+
 def patch_youtube_dl():
     utils.unified_strdate.__code__ = fixed_unified_strdate.__code__
     utils.unified_timestamp.__code__ = fixed_unified_timestamp.__code__
+    # Fix bug affecting embedded python applications: https://kodi.wiki/view/Python_Problems
+    utils.datetime.datetime = proxydt
     sys.stderr.__class__ = ReplacementStdErr
     try:
         import _subprocess


### PR DESCRIPTION
After a boring debugging session (step-by-step and breakpoints), I have finally found the "second video playback in sequence" bug (I have reported in #36).

It depends on a bug affecting only the embedded python applications (eg. Kodi addons), it's related to the `datetime.strptime()` (used in yt-dlp) when called the second time.

You can find a lot of function call `datetime.datetime.strptime()` in *lib/youtube_dl/utils.py*.

More info here:
https://github.com/python/cpython/issues/71587
https://github.com/xbmc/xbmc/issues/17311
https://kodi.wiki/view/Python_Problems

I'm sure you'll become a python lover now ;)

OT: where can I report bugs regard the Yatse application? Forum?
